### PR TITLE
ci: build and deploy via GitHub Actions with PR previews

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+# Shell scripts must stay LF so they run on the Linux CI runners.
+*.sh text eol=lf

--- a/.github/scripts/gh-pages-deploy.sh
+++ b/.github/scripts/gh-pages-deploy.sh
@@ -1,0 +1,116 @@
+#!/usr/bin/env bash
+#
+# DIY GitHub Pages publisher for the `gh-pages` branch — no third-party actions.
+#
+# Publishes a built site into a subtree of `gh-pages` (or its root for
+# production) while leaving every sibling subtree untouched. This is what lets a
+# production site and any number of PR previews coexist on the same branch:
+#
+#   gh-pages/
+#     index.html            <- production (DEST_DIR="")
+#     CNAME .nojekyll ...
+#     previews/
+#       pr-12/  ...          <- preview  (DEST_DIR="previews/pr-12")
+#       pr-15/  ...
+#
+# Environment inputs:
+#   MODE        deploy | remove                     (default: deploy)
+#   DEST_DIR    subtree on gh-pages; "" = prod root
+#   SOURCE_DIR  built site to publish               (required when MODE=deploy)
+#   GITHUB_TOKEN / GITHUB_REPOSITORY / GITHUB_SHA   (provided by Actions)
+#
+set -euo pipefail
+
+MODE="${MODE:-deploy}"
+DEST_DIR="${DEST_DIR:-}"
+SOURCE_DIR="${SOURCE_DIR:-}"
+BRANCH="gh-pages"
+REMOTE="https://x-access-token:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
+
+if [ "$MODE" = "deploy" ] && [ -z "$SOURCE_DIR" ]; then
+  echo "SOURCE_DIR is required when MODE=deploy" >&2
+  exit 1
+fi
+if [ "$MODE" = "remove" ] && [ -z "$DEST_DIR" ]; then
+  echo "refusing to remove the production root" >&2
+  exit 1
+fi
+
+# Resolve the source to an absolute path (publish() runs from a temp dir).
+if [ "$MODE" = "deploy" ]; then
+  SOURCE_DIR="$(cd "$SOURCE_DIR" && pwd)"
+fi
+
+# One attempt: clone the current branch, splice in the new files, push.
+# Re-cloning per attempt means a concurrent deploy (prod vs. preview) is picked
+# up on retry instead of being clobbered.
+publish() {
+  local tmp
+  tmp="$(mktemp -d)"
+
+  if git ls-remote --exit-code --heads "$REMOTE" "$BRANCH" >/dev/null 2>&1; then
+    git clone --quiet --branch "$BRANCH" --single-branch --depth 1 "$REMOTE" "$tmp"
+  else
+    if [ "$MODE" = "remove" ]; then
+      echo "Branch $BRANCH does not exist; nothing to remove."
+      rm -rf "$tmp"
+      return 0
+    fi
+    # First ever deploy: start an empty orphan branch.
+    git clone --quiet --depth 1 "$REMOTE" "$tmp"
+    git -C "$tmp" checkout --quiet --orphan "$BRANCH"
+    git -C "$tmp" rm -rfq . 2>/dev/null || true
+  fi
+
+  git -C "$tmp" config user.name "github-actions[bot]"
+  git -C "$tmp" config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+  local msg
+  if [ "$MODE" = "remove" ]; then
+    rm -rf "${tmp:?}/${DEST_DIR}"
+    msg="chore(preview): remove ${DEST_DIR}"
+  elif [ -z "$DEST_DIR" ]; then
+    # Production: replace root-level files but keep previews/ (and .git).
+    find "$tmp" -mindepth 1 -maxdepth 1 \
+      ! -name '.git' ! -name 'previews' -exec rm -rf {} +
+    cp -a "$SOURCE_DIR"/. "$tmp"/
+    touch "$tmp/.nojekyll"
+    msg="deploy: production @ ${GITHUB_SHA:0:7}"
+  else
+    # Preview: replace just this subtree.
+    rm -rf "${tmp:?}/${DEST_DIR}"
+    mkdir -p "$tmp/$DEST_DIR"
+    cp -a "$SOURCE_DIR"/. "$tmp/$DEST_DIR"/
+    touch "$tmp/.nojekyll"
+    msg="deploy: ${DEST_DIR} @ ${GITHUB_SHA:0:7}"
+  fi
+
+  git -C "$tmp" add -A
+  if git -C "$tmp" diff --cached --quiet; then
+    echo "No changes to publish."
+    rm -rf "$tmp"
+    return 0
+  fi
+
+  git -C "$tmp" commit --quiet -m "$msg"
+  if git -C "$tmp" push --quiet origin "HEAD:$BRANCH"; then
+    echo "Published: $msg"
+    rm -rf "$tmp"
+    return 0
+  fi
+
+  echo "Push rejected (branch moved underneath us)."
+  rm -rf "$tmp"
+  return 1
+}
+
+for attempt in 1 2 3 4 5; do
+  if publish; then
+    exit 0
+  fi
+  echo "Retrying (attempt ${attempt}/5)…"
+  sleep $((attempt * 3))
+done
+
+echo "Failed to publish to ${BRANCH} after 5 attempts." >&2
+exit 1

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,42 @@
+name: Deploy site
+
+on:
+  push:
+    branches: [master]
+    paths:
+      - "docs/**"
+      - ".github/workflows/deploy.yml"
+      - ".github/scripts/gh-pages-deploy.sh"
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+# Let an in-flight production deploy finish rather than cancelling it.
+concurrency:
+  group: deploy-production
+  cancel-in-progress: false
+
+jobs:
+  build-and-deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      # Official GitHub action: builds with the pinned github-pages gem
+      # environment (same as the legacy Pages worker), so no Ruby/bundle setup.
+      - name: Build with Jekyll
+        uses: actions/jekyll-build-pages@v1
+        with:
+          source: ./docs
+          destination: ./_site
+          token: ${{ github.token }}
+
+      - name: Publish to gh-pages (production root)
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+          MODE: deploy
+          DEST_DIR: ""
+          SOURCE_DIR: _site
+        run: bash .github/scripts/gh-pages-deploy.sh

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -39,4 +39,8 @@ jobs:
           MODE: deploy
           DEST_DIR: ""
           SOURCE_DIR: _site
-        run: bash .github/scripts/gh-pages-deploy.sh
+        run: |
+          # jekyll-build-pages (Docker action) writes _site as root; reclaim it
+          # so cp preserves runner ownership on the gh-pages copy.
+          sudo chown -R "$(id -u):$(id -g)" _site
+          bash .github/scripts/gh-pages-deploy.sh

--- a/.github/workflows/pr-preview.yml
+++ b/.github/workflows/pr-preview.yml
@@ -1,0 +1,112 @@
+name: PR preview
+
+on:
+  pull_request:
+    types: [opened, reopened, synchronize, closed]
+
+permissions:
+  contents: write # push the built preview to gh-pages
+  pull-requests: write # leave the sticky preview-link comment
+
+# Newest commit on a PR wins; older in-flight preview builds are cancelled.
+concurrency:
+  group: preview-${{ github.event.number }}
+  cancel-in-progress: true
+
+jobs:
+  deploy:
+    if: github.event.action != 'closed'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Configure preview build
+        env:
+          PR: ${{ github.event.number }}
+        run: |
+          # Serve theme assets and internal links under the preview sub-path.
+          sed -i "s|^baseurl:.*|baseurl: \"/previews/pr-${PR}\"|" docs/_config.yml
+          # Keep preview page views out of the production analytics property.
+          sed -i 's|^  provider: "google-gtag"|  provider: false|' docs/_config.yml
+
+      - name: Build with Jekyll
+        uses: actions/jekyll-build-pages@v1
+        with:
+          source: ./docs
+          destination: ./_site
+          token: ${{ github.token }}
+
+      - name: Post-process preview output
+        env:
+          PR: ${{ github.event.number }}
+        run: |
+          # Rewrite root-absolute asset paths (e.g. images referenced as
+          # /assets/... in post markdown) so they resolve under the preview.
+          # Theme assets are already prefixed via baseurl, so they don't match.
+          find _site -name '*.html' -exec \
+            sed -i "s|=\"/assets/|=\"/previews/pr-${PR}/assets/|g" {} +
+          # The apex domain belongs to production only.
+          rm -f _site/CNAME
+
+      - name: Publish preview to gh-pages
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+          MODE: deploy
+          DEST_DIR: previews/pr-${{ github.event.number }}
+          SOURCE_DIR: _site
+        run: bash .github/scripts/gh-pages-deploy.sh
+
+      - name: Comment preview link
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const pr = context.issue.number;
+            const url = `https://kazo0.dev/previews/pr-${pr}/`;
+            const marker = '<!-- pr-preview -->';
+            const body = [
+              marker,
+              '### 🔎 Preview deployed',
+              '',
+              `**${url}**`,
+              '',
+              `Built from ${context.sha.substring(0, 7)}. Updates on every push; removed when the PR closes.`,
+            ].join('\n');
+            const { data: comments } = await github.rest.issues.listComments({
+              ...context.repo, issue_number: pr, per_page: 100,
+            });
+            const existing = comments.find(c => c.body && c.body.includes(marker));
+            if (existing) {
+              await github.rest.issues.updateComment({ ...context.repo, comment_id: existing.id, body });
+            } else {
+              await github.rest.issues.createComment({ ...context.repo, issue_number: pr, body });
+            }
+
+  cleanup:
+    if: github.event.action == 'closed'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Remove preview from gh-pages
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+          MODE: remove
+          DEST_DIR: previews/pr-${{ github.event.number }}
+        run: bash .github/scripts/gh-pages-deploy.sh
+
+      - name: Update comment
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const pr = context.issue.number;
+            const marker = '<!-- pr-preview -->';
+            const body = `${marker}\n### 🧹 Preview removed\n\nThe preview site for this PR has been torn down.`;
+            const { data: comments } = await github.rest.issues.listComments({
+              ...context.repo, issue_number: pr, per_page: 100,
+            });
+            const existing = comments.find(c => c.body && c.body.includes(marker));
+            if (existing) {
+              await github.rest.issues.updateComment({ ...context.repo, comment_id: existing.id, body });
+            }

--- a/.github/workflows/pr-preview.yml
+++ b/.github/workflows/pr-preview.yml
@@ -41,6 +41,9 @@ jobs:
         env:
           PR: ${{ github.event.number }}
         run: |
+          # jekyll-build-pages is a Docker action and writes _site as root;
+          # reclaim it so this non-root step can edit the files in place.
+          sudo chown -R "$(id -u):$(id -g)" _site
           # Rewrite root-absolute asset paths (e.g. images referenced as
           # /assets/... in post markdown) so they resolve under the preview.
           # Theme assets are already prefixed via baseurl, so they don't match.

--- a/.github/workflows/pr-preview.yml
+++ b/.github/workflows/pr-preview.yml
@@ -15,7 +15,7 @@ concurrency:
 
 jobs:
   deploy:
-    if: github.event.action != 'closed'
+    if: github.event.action != 'closed' && github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -86,9 +86,8 @@ jobs:
             }
 
   cleanup:
-    if: github.event.action == 'closed'
+    if: github.event.action == 'closed' && github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
-    steps:
       - name: Checkout
         uses: actions/checkout@v4
 

--- a/docs/robots.txt
+++ b/docs/robots.txt
@@ -1,0 +1,4 @@
+User-agent: *
+Disallow: /previews/
+
+Sitemap: https://kazo0.dev/sitemap.xml


### PR DESCRIPTION
## What & why

Moves production deployment off the **legacy GitHub Pages build worker** onto **GitHub Actions**, and adds **per-PR preview sites** hosted on the same `kazo0.dev` domain under `/previews/pr-N/`.

Inspired by [Dan Kingdom's PR previews](https://blog.danskingdom.com/Host-website-PR-previews-on-GitHub-Pages-for-free/) and [Joseph Guadagno's Pages→Actions migration](https://www.josephguadagno.net/2024/04/03/migrate-to-github-actions-from-pages-legacy-worker), but using **only** `github.com/actions/*` actions plus hand-written `git` — no third-party action plugins.

## How it works

Both prod and previews build in CI and publish to a `gh-pages` branch as independent subtrees, so they coexist (GitHub Pages allows only one deploy source, and the subtree-preview model requires the branch source):

- **`deploy.yml`** — on push to `master`, builds `docs/` with `actions/jekyll-build-pages` (GitHub's pinned `github-pages` gem, faithful to the legacy worker) and publishes to the `gh-pages` root.
- **`pr-preview.yml`** — builds each PR with `baseurl=/previews/pr-N`, publishes to `gh-pages/previews/pr-N/`, posts a sticky comment with the link, and removes it on close.
- **`.github/scripts/gh-pages-deploy.sh`** — writes a single subtree of `gh-pages` while preserving the rest.
- **`docs/robots.txt`** — `Disallow: /previews/`.

Previews build with analytics disabled and rewrite root-absolute `/assets/…` paths so draft-post images resolve.

## Cutover (after merge — no downtime)

1. Merging runs `deploy.yml`, which **creates** the `gh-pages` branch. The live site is unaffected (still served from `master`/`docs`).
2. Verify the `gh-pages` branch.
3. **Settings → Pages → Source → Deploy from a branch → `gh-pages` / `(root)`.** The `CNAME` file keeps the custom domain. Rollback = flip back to `master`/`docs`.

## Notes

- Previews only run for PRs from branches in this repo (fork PRs get a read-only token by GitHub's design).
- This PR itself will exercise the preview build; its `/previews/pr-N/` link only serves once the Pages source is flipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015qbqd2YaRmN71afcBQFJ9z
