### PR TITLE
build(deps): add csv, base64, bigdecimal for Ruby 3.4 compatibility

### DIFF
--- a/docs/Gemfile
+++ b/docs/Gemfile
@@ -35,3 +35,8 @@ gem 'jekyll-seo-tag'
 gem 'jemoji'
 gem "webrick", "~> 1.8"
 gem 'jekyll-sitemap'
+
+# Ruby 3.4 dropped these from the default gems; Jekyll 3.9.x still requires them.
+gem "csv"
+gem "base64"
+gem "bigdecimal"

--- a/docs/Gemfile.lock
+++ b/docs/Gemfile.lock
@@ -26,6 +26,7 @@ GEM
     commonmarker (0.23.10)
     concurrent-ruby (1.3.4)
     connection_pool (2.4.1)
+    csv (3.3.5)
     dnsruby (1.72.2)
       simpleidn (~> 0.2.1)
     drb (2.2.1)
@@ -42,8 +43,7 @@ GEM
       logger
     faraday-net_http (3.3.0)
       net-http
-    ffi (1.17.0-arm64-darwin)
-    ffi (1.17.0-x64-mingw-ucrt)
+    ffi (1.17.0)
     forwardable-extended (2.6.0)
     gemoji (3.0.1)
     github-pages (228)
@@ -222,6 +222,7 @@ GEM
       rb-inotify (~> 0.9, >= 0.9.10)
     logger (1.6.1)
     mercenary (0.3.6)
+    mini_portile2 (2.8.9)
     minima (2.5.1)
       jekyll (>= 3.5, < 5.0)
       jekyll-feed (~> 0.9)
@@ -229,9 +230,8 @@ GEM
     minitest (5.25.1)
     net-http (0.4.1)
       uri
-    nokogiri (1.16.7-arm64-darwin)
-      racc (~> 1.4)
-    nokogiri (1.16.7-x64-mingw-ucrt)
+    nokogiri (1.16.7)
+      mini_portile2 (~> 2.8.2)
       racc (~> 1.4)
     octokit (4.25.1)
       faraday (>= 1, < 3)
@@ -272,9 +272,13 @@ GEM
 
 PLATFORMS
   arm64-darwin-23
+  arm64-darwin-25
   x64-mingw-ucrt
 
 DEPENDENCIES
+  base64
+  bigdecimal
+  csv
   github-pages (~> 228)
   http_parser.rb (~> 0.6.0)
   jekyll-feed (~> 0.12)


### PR DESCRIPTION
## Summary

Isolates the Ruby 3.4 toolchain fixes that were needed to build/serve the Jekyll site locally, keeping them out of the in-progress blog post branch.

- Ruby 3.4 removed `csv`, `base64`, and `bigdecimal` from the default gems, but Jekyll 3.9.x (github-pages 228) still requires them — declared explicitly in the `Gemfile`.
- Refreshed `Gemfile.lock`: added the `arm64-darwin-25` platform and let `ffi`/`nokogiri` resolve without hardcoded platform-specific pins.

## Testing

- `cd docs && bundle install`
- `cd docs && bundle exec jekyll build`

🤖 Generated with [Claude Code](https://claude.com/claude-code)