### PR TITLE
chore: add one-shot bin/serve script for local dev

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,6 +10,23 @@ All Jekyll source lives under `docs/`. Run all commands from there.
 
 ## Commands
 
+### Running locally
+
+The fastest way to get the site up — from anywhere in the repo. `bin/serve` installs any
+missing gems (only when needed), then serves with live reload at <http://localhost:4000>.
+Extra flags pass straight through to `jekyll serve`.
+
+```bash
+bin/serve                 # published posts, live reload
+bin/serve --drafts        # also serve work-in-progress posts in _drafts/
+bin/serve --port 5000     # any jekyll serve flag passes through
+
+npm run serve             # equivalent, via npm
+npm run serve:drafts
+```
+
+### Manual (from `docs/`)
+
 ```bash
 # Serve locally with live reload
 cd docs && bundle exec jekyll serve

--- a/bin/serve
+++ b/bin/serve
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+#
+# serve — get the kazo0.dev Jekyll site running locally in one shot.
+#
+# Installs any missing gems, then serves with live reload so the browser
+# refreshes as you edit posts. Any extra args are passed straight through
+# to `jekyll serve`, e.g.:
+#
+#   bin/serve --drafts        # also serve work-in-progress posts in _drafts/
+#   bin/serve --port 5000     # serve on a different port
+#
+set -euo pipefail
+
+# Resolve the repo root from this script's location so it works from anywhere.
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$REPO_ROOT/docs"
+
+# Only run bundle install when something is actually missing — keeps restarts fast.
+if ! bundle check >/dev/null 2>&1; then
+  echo "==> Installing Ruby gems (first run or Gemfile changed)…"
+  bundle install
+fi
+
+echo "==> Serving at http://localhost:4000 — press Ctrl+C to stop"
+exec bundle exec jekyll serve --livereload "$@"

--- a/package.json
+++ b/package.json
@@ -4,6 +4,8 @@
   "private": true,
   "description": "Tooling for the kazo0.dev Jekyll blog: markdownlint + Conventional Commits enforcement",
   "scripts": {
+    "serve": "bin/serve",
+    "serve:drafts": "bin/serve --drafts",
     "lint:md": "markdownlint-cli2",
     "lint:md:fix": "markdownlint-cli2 --fix",
     "prepare": "husky"


### PR DESCRIPTION
## What

Adds a single command to get the site running locally, so you no longer need the `cd docs && bundle install && bundle exec jekyll serve` dance.

- **`bin/serve`** — resolves the repo root (works from anywhere), runs `bundle install` only when gems are missing (`bundle check` gate → fast restarts), then serves with `--livereload` at <http://localhost:4000>. Extra flags pass straight through to `jekyll serve`.
- **npm aliases** — `npm run serve` and `npm run serve:drafts`.
- **CLAUDE.md** — new "Running locally" section documenting the workflow, with the manual `docs/` commands kept below it.

## Usage

```bash
bin/serve                 # published posts, live reload
bin/serve --drafts        # include _drafts/
bin/serve --port 5000     # any jekyll serve flag passes through
npm run serve             # equivalent, via npm
```

## Testing

Ran `bin/serve` locally — site came up on `localhost:4000` (HTTP 200), remote theme + feed generating, live reload active.

🤖 Generated with [Claude Code](https://claude.com/claude-code)