### PR TITLE
fix(ci): take preview scripts from the launching commit, not the PR merge ref

### DIFF
--- a/.github/workflows/pr-preview.yml
+++ b/.github/workflows/pr-preview.yml
@@ -38,6 +38,17 @@ jobs:
           # manual rebuild lands on the PR rather than on master.
           ref: refs/pull/${{ github.event.number || inputs.pr }}/merge
 
+      # A PR's merge ref is only recomputed when the PR itself moves, so on a
+      # manual rebuild it can be a tree that predates the scripts this workflow
+      # calls. Take them from the commit the run was launched from instead:
+      # the merge commit on a pull_request, so a PR can still test its own
+      # changes to them, and the default branch on a manual rebuild.
+      - name: Sync preview tooling
+        run: |
+          set -euo pipefail
+          git fetch --depth=1 origin "$GITHUB_SHA"
+          git checkout "$GITHUB_SHA" -- .github/scripts
+
       - name: Configure preview build
         run: |
           # Serve theme assets and internal links under the preview sub-path.


### PR DESCRIPTION
Manually rebuilding the four open PRs' previews (the follow-up step from #35) failed on all four:

```text
python3: can't open file '.github/scripts/preview-slim.py': [Errno 2] No such file or directory
```

## Cause

`workflow_dispatch` loads the **workflow** from the default branch but the job checks out `refs/pull/N/merge`. That ref is only recomputed when the PR itself moves — these PRs are from July, so their merge trees predate the scripts the workflow now calls. New workflow, old tree.

## Fix

Restore `.github/scripts` from `$GITHUB_SHA` after checkout. That resolves to exactly the right version in both cases:

| event | `$GITHUB_SHA` | effect |
|---|---|---|
| `pull_request` | the PR's merge commit | unchanged — a PR can still test its own script changes |
| `workflow_dispatch` | the default branch | the scripts that belong with the dispatched workflow |

## Verified

Dispatched from this branch (so the branch's own workflow ran) for all four PRs — all green:

| preview | before | after | bundled images |
|---|---|---|---|
| pr-23 | 267.2 MB | 2.4 MB | 0 |
| pr-27 | 269.6 MB | 4.8 MB | 4 |
| pr-31 | 267.5 MB | 2.8 MB | 2 |
| pr-34 | 267.2 MB | 2.5 MB | 0 |

Spot-checked pr-27 live: the page loads, its four new `chefs-home` images serve from `/previews/pr-27/...`, and images it didn't touch resolve at the production root.

## Result: the 1 GB warning is gone

With this plus the GC sweep of the merged pr-22, `gh-pages` is now:

```
71.3 MB  TOTAL
57.3 MB  assets/
12.5 MB  previews/   (4 previews)
```

And the Pages deploy:

```text
Artifact github-pages has been successfully uploaded! Final size is 64764888 bytes
```

**1,648,339,271 → 64,764,888 bytes.** 96% smaller, 6% of the limit, no warning.