### PR TITLE
Add dotfiles cross-machine setup post

### DIFF
--- a/docs/_posts/2026-08-22-dotfiles.md
+++ b/docs/_posts/2026-08-22-dotfiles.md
@@ -1,0 +1,164 @@
+---
+title: "Syncing my terminal (and my agents) across machines with dotfiles"
+category: uno-general
+header:
+  teaser: /assets/images/dotfiles/hero.png
+  og_image: /assets/images/dotfiles/hero.png
+tags: [dotfiles, terminal, shell, zsh, powershell, oh-my-posh, claude-code, agents, dev-containers]
+---
+
+I bounce between a lot of machines. There's my Windows dev box where most of the real Uno work happens, a MacBook, the odd Linux box, WSL when I need a Unix shell on Windows, and lately a growing pile of dev containers. Every one of them wants my shell to feel the same: my prompt, my aliases, my PATH tweaks, and (increasingly) my coding agents all configured the way I like them.
+
+For years my "system" for this was to open an old machine, squint at its `.zshrc`, and copy-paste the bits I remembered into the new one. It works right up until it doesn't. You forget an alias, one machine drifts out of sync with another, and you spend twenty minutes wondering why `dotnet tool` isn't on your PATH on the laptop but is on the desktop.
+
+So I finally did the thing every developer eventually does: I put it all in a [dotfiles repo][dotfiles-repo]. Let's walk through how it's set up, because the agentic side of it turned out to be the most useful part and I think it's worth sharing.
+
+## The idea: one source of truth, symlinked everywhere
+
+The whole approach rests on one simple trick: the files in the repo are the single source of truth, and each machine symlinks its real config locations back to the repo.
+
+So `~/.zshrc` on any given machine isn't a copy of my zsh config, it's a symlink pointing at `zsh/zshrc` inside the cloned repo. That means editing the linked file IS editing the repo file; they're literally the same file on disk. The day-to-day loop becomes:
+
+1. Edit a config file (either in the repo, or the linked location, same thing).
+2. `git commit && git push`.
+3. On the next machine, `git pull` and restart the shell.
+
+That's it. No copy-paste, no drift. A change I make on the Mac shows up on the Windows box after a pull.
+
+## One script to link it all
+
+Cloning the repo doesn't do anything on its own; you need those symlinks created. That's what the setup scripts are for: `setup.sh` for macOS/Linux/WSL and `Setup.ps1` for Windows. You clone the repo anywhere you like and run the script once:
+
+```sh
+git clone <repo-url> ~/src/dotfiles
+~/src/dotfiles/setup.sh
+```
+
+The heart of the script is a little map of "repo file → where it should be linked," and a loop that creates each link:
+
+```sh
+links=(
+    "$repo_root/zsh/zshrc|$HOME/.zshrc"
+    "$repo_root/zsh/zprofile|$HOME/.zprofile"
+    "$repo_root/bash/bashrc|$HOME/.bashrc.shared"
+    "$repo_root/oh-my-posh/steve.omp.json|$HOME/Documents/oh-my-posh/steve.omp.json"
+    # ...
+)
+```
+
+A couple of things I made sure it does, because a setup script you can't trust is worse than no script at all:
+
+- **It backs up before it clobbers.** If there's already a REAL file where a symlink should go, it gets copied to `<name>.bak` before being replaced. Nothing of yours gets silently nuked.
+- **It's safe to re-run.** A link that's already correct is left alone. So running the script again after adding a new file is a no-op for everything else.
+
+On Windows there's one extra hoop: you need Developer Mode turned on (or an elevated shell) so the OS will let you create symlinks without admin rights. Once that's on, `pwsh -File Setup.ps1` does the same job.
+
+## Not owning `~/.bashrc`
+
+Zsh was easy: I own `~/.zshrc`, so I just link it. Bash was trickier. On most Linux distros the `~/.bashrc` isn't really mine; the distro ships one, and there's often machine-specific stuff in there (WSL likes to append Windows paths, for example). I didn't want to blow that away.
+
+So the shared bash config links to `~/.bashrc.shared` instead, and the setup script appends a single line to the real `~/.bashrc` to source it, once and idempotently:
+
+```sh
+[ -f ~/.bashrc.shared ] && . ~/.bashrc.shared   # shared dotfiles
+```
+
+The distro's file and any machine-specific bits stay put, and my shared stuff rides along on top.
+
+That shared bash file also has to survive running on both macOS and Linux, so everything in it is guarded. Homebrew might live at `/opt/homebrew` (macOS) or `/home/linuxbrew` (Linux); a tool like `pyenv` or `nvm` might not be installed at all. Rather than assume, it checks first:
+
+```sh
+# oh-my-posh prompt, only if it's actually installed
+if command -v oh-my-posh >/dev/null 2>&1 && [ -f "$HOME/Documents/oh-my-posh/steve.omp.json" ]; then
+    eval "$(oh-my-posh init bash --config "$HOME/Documents/oh-my-posh/steve.omp.json")"
+fi
+```
+
+A machine that doesn't have a given tool just skips that block silently instead of spitting out an error on every new shell.
+
+## The prompt
+
+The prompt itself is [oh-my-posh][oh-my-posh], with a single theme file (`steve.omp.json`) shared across zsh, bash, and PowerShell. Since all three shells point at the same JSON, my prompt looks identical no matter where I am or which shell I'm in. Tweak the theme once, push, pull, done.
+
+## Keeping secrets out of the repo
+
+The obvious trap with a public dotfiles repo is leaking a token. The rule here is simple: NOTHING secret is ever committed. Machine-local values and credentials go in a `~/.zshrc.local` (or `~/.bashrc.local`) file that the shared config sources at the end if it exists:
+
+```zsh
+# ~/.zshrc.local  (git-ignored, never leaves the machine)
+export SOME_GITHUB_TOKEN="..."
+```
+
+Those `*.local` files are in `.gitignore`, so they physically can't be committed by accident. The shared config just does a `[ -f ~/.zshrc.local ] && source ~/.zshrc.local` and moves on if it's not there.
+
+One more gotcha worth mentioning while we're on the subject of things that bite you: line endings. Shell files with CRLF endings break outright when a Unix shell tries to source them, and a Windows checkout with `core.autocrlf=true` will happily hand you CRLF copies. A `.gitattributes` that pins the shell files to `eol=lf` keeps a Windows clone from poisoning WSL:
+
+```gitattributes
+*.sh          text eol=lf
+zsh/zshrc     text eol=lf
+bash/bashrc   text eol=lf
+```
+
+## The part I actually care about: my agents
+
+Here's where this stopped being a generic dotfiles repo and started earning its keep. I run multiple CLI coding agents against the same repos (Claude Code, Codex, and Kimi), and I want them to behave consistently no matter the machine. Dotfiles turned out to be the perfect place for that.
+
+### Shared instructions across every agent
+
+I keep one tool-agnostic `AGENTS.md`: how I like commits written, that "done" means it builds and the tests pass, which Uno targets to validate against, and so on. Rather than maintain a copy per tool, that one file is the canonical source and gets fanned out:
+
+```text
+repo/agents/AGENTS.md ─→ ~/.agents/AGENTS.md ─→ ~/.codex/AGENTS.md
+```
+
+Kimi reads `~/.agents/AGENTS.md` natively, Codex gets a symlink, and Claude Code imports it from `~/.claude/CLAUDE.md` with a single `@../.agents/AGENTS.md` line. Edit the one file, and all three agents pick up the change on the next run.
+
+### Shared skills
+
+If you read my [earlier post on Agent Skills]({% post_url 2026-02-23-agent-skills-intro %}), you know I'm a fan. The catch is that skills are only useful if your agents actually HAVE them, on every machine. So the setup scripts shallow-clone a set of upstream skill repos and symlink each skill into a shared `~/.agents/skills` store, which then fans out to each tool:
+
+```text
+upstream repos ─→ ~/.agents/skills ─→ ~/.claude/skills, ~/.codex/skills
+```
+
+Right now that pulls from the [Uno Platform Studio][uno-studio] skills (Uno, Toolkit, MVUX) and the [.NET skills][dotnet-skills] repo. Re-running setup does a `git pull` on each source and relinks, so updating my whole skills library across every agent is one command. And because skills are generated rather than tracked, none of that clutters the dotfiles repo itself.
+
+### Switching Claude Code accounts without re-logging-in
+
+This one is my favorite. I have a work account and a personal account for Claude Code, and I used to `/login` back and forth constantly. Now a small shared shell function swaps between them by pointing `CLAUDE_CONFIG_DIR` at a different config directory:
+
+```sh
+claude-profile              # who am I right now?
+claude-personal             # switch, and make it the default for new shells
+claude-work
+```
+
+Each profile is a full config dir with its own credentials, project history, and MCP tokens, so both accounts stay signed in at once and switching is instant. Two terminals can even drive two different accounts side by side. The active choice is saved and re-applied by the shell config in every new terminal, so it follows me around like everything else here.
+
+## Every dev container, for free
+
+The nice surprise: VS Code lets you point at a [dotfiles repository][devcontainer-dotfiles] and run an install command whenever it spins up a dev container. Since my setup script already knows how to merge in my Claude Code defaults, I wired it straight into my VS Code User settings (not any single repo's):
+
+```json
+"dotfiles.repository": "kazo0/dotfiles",
+"dotfiles.targetPath": "~/dotfiles",
+"dotfiles.installCommand": "setup.sh --claude-only"
+```
+
+Configure that once and every new dev container comes up with my agent config already applied, no per-repo files, nothing to remember. The `--claude-only` flag keeps it lightweight (just the Claude settings, skipping the shell symlinks and skill cloning), but if I want the full prompt-and-aliases experience in a container too, dropping the flag gets me that.
+
+## Conclusion
+
+None of the pieces here are complicated on their own. It's git, symlinks, and a shell script. But together they turn "set up a new machine" from an afternoon of copy-paste into `git clone`, run one script, and get back to work. The agent config riding along in the same repo is what pushed it from "nice to have" to "I'd be annoyed without it," especially now that so much of my day runs through Claude Code and friends.
+
+If you want to steal the setup wholesale or just crib a few ideas, the whole thing is on [GitHub][dotfiles-repo]. Fair warning that the specifics are shaped around my own tools and paths, but that's kind of the point of dotfiles. Make them yours.
+
+Catch you in the next one :wave:
+
+[dotfiles-repo]: https://github.com/kazo0/dotfiles
+[oh-my-posh]: https://ohmyposh.dev/
+[devcontainer-dotfiles]: https://code.visualstudio.com/docs/devcontainers/containers#_personalizing-with-dotfile-repositories
+[uno-studio]: https://github.com/unoplatform/studio
+[dotnet-skills]: https://github.com/dotnet/skills
+
+{% include links.md %}


### PR DESCRIPTION
## Summary

A new `uno-general` post walking through Steve's [dotfiles repo](https://github.com/kazo0/dotfiles) as a way to sync terminal, shell, and prompt config across machines, with a heavy focus on the agentic angle: sharing one `AGENTS.md` across Claude Code / Codex / Kimi, a shared skills store cloned from upstream (unoplatform/studio, dotnet/skills), Claude Code account profiles via `CLAUDE_CONFIG_DIR`, and wiring `setup.sh --claude-only` into VS Code dev containers. Structured as the usual problem → solution arc with real code pulled straight from the repo (symlink map, OS-guarded bash, `.gitattributes` LF pinning, `*.local` secrets).

## Why now

Steve requested it. It's a natural companion to the earlier [Agent Skills post](https://kazo0.dev) (linked inline via `{% post_url %}`) and fits the blog's growing agentic-development thread.

## Sources consulted

- The dotfiles repo itself (local read-only clone at `/home/pi/repos/dotfiles`): README, `setup.sh`, `zsh/zshrc`, `bash/bashrc`, `agents/AGENTS.md`, `claude/*`, `.gitattributes`. All code snippets are lifted from the actual files.
- Repo `AGENTS.md`/`CLAUDE.md` for front matter, linting, and commit conventions.

## Image checklist

- [ ] `docs/assets/images/dotfiles/hero.png` — teaser / og_image (does not exist yet)

No inline screenshots are used; the post is code-block driven, so `hero.png` is the only asset required before merge.

## Notes

- Agent-drafted for Steve's review.
- Passed the Voice Guardian (`VERDICT: APPROVED`) after three rounds; the guardian flagged em-dashes, italic/bold-for-emphasis, and a `## Wrapping up` heading, all of which were fixed (emphasis is now ALL-CAPS per the corpus, heading is `## Conclusion`).
- Internal link to the Agent Skills post uses `{% post_url 2026-02-23-agent-skills-intro %}` rather than a reference-style link, since the site has no custom permalink set — worth confirming it resolves in the PR preview.
- New shared link IDs (`oh-my-posh`, `devcontainer-dotfiles`, `uno-studio`, `dotnet-skills`, `dotfiles-repo`) are defined locally at the bottom of the post rather than in `links.md`, since they're specific to this post.

🤖 Generated with [Claude Code](https://claude.com/claude-code)